### PR TITLE
fix: 결과 페이지를 EntryLayout에서 분리하여 비로그인 사용자도 접근 가능하게 변경

### DIFF
--- a/FiTime-FE/src/App.tsx
+++ b/FiTime-FE/src/App.tsx
@@ -25,8 +25,9 @@ export default function App() {
           <Route path="timetable" element={<EntryTimetable />} />
           <Route path="rank" element={<EntryRank />} />
           <Route path="complete" element={<EntryComplete />} />
-          <Route path="result" element={<ViewResult />} />
         </Route>
+
+        <Route path="/room/:room_link/result" element={<ViewResult />} />
       </Routes>
     </>
   );

--- a/FiTime-FE/src/pages/EntryLayout.tsx
+++ b/FiTime-FE/src/pages/EntryLayout.tsx
@@ -28,11 +28,6 @@ export function EntryLayout() {
     fetchRoomInfo();
   }, [room_link, navigate]);
 
-  // API 연동 전 테스트용 더미 방 정보
-  // useEffect(() => {
-  //   setRoomInfo({ title: '방 제목', descriptions: '방 설명' });
-  // }, []);
-
   if (!roomInfo) {
     return (
       <div className="w-full min-h-screen bg-gray-100">
@@ -49,7 +44,7 @@ export function EntryLayout() {
     <div className="w-full min-h-screen bg-gray-100">
       <div className="w-[375px] mx-auto bg-white min-h-screen">
         <main>
-          <Outlet context={roomInfo} />
+          <Outlet />
         </main>
       </div>
     </div>

--- a/FiTime-FE/src/pages/EntryRank.tsx
+++ b/FiTime-FE/src/pages/EntryRank.tsx
@@ -18,6 +18,7 @@ import { buildRankMatrix } from '@/components/timetable/rankMatrix';
 export function EntryRank() {
   const navigate = useNavigate();
 
+  const reset = useEntryStore((state) => state.reset);
   const user_id = useEntryStore((state) => state.user_id);
   const timetableResult = useEntryStore((state) => state.timetable);
   const rankStore1 = useEntryStore((state) => state.rank1);
@@ -39,6 +40,13 @@ export function EntryRank() {
   const [rank3, setRank3] = useState<string>(() =>
     rankStore3 ? buildKey(rankStore3) : '',
   );
+
+  // 로그인 체크: user_id가 없으면 EntryUser로 리다이렉트
+  useEffect(() => {
+    if (!user_id) {
+      navigate('../', { replace: true });
+    }
+  }, [user_id, navigate]);
 
   useEffect(() => {
     if (!timetableResult || timetableResult.length === 0) {
@@ -126,12 +134,34 @@ export function EntryRank() {
     }
   };
 
+  const onDeleteUser = async () => {
+    try {
+      await api.delete<{ status: string; message: string }>(
+        `/user/delete/${user_id}`,
+      );
+      reset();
+      navigate('/', { replace: true });
+    } catch (err) {
+      alert('방 나가기에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
   return (
     <>
       <div className="flex flex-col px-5 py-7.5 gap-6">
         <Progress value={75} />
+
         <div className="flex flex-col w-full gap-1 text-left">
-          <div className="w-full">선호하는 1~3순위를 선택해주세요</div>
+          <div className="flex w-full justify-between">
+            <div>선호하는 1~3순위를 선택해주세요</div>
+            <Button
+              className="text-xs h-6 px-2 bg-gray-100 text-red-600 hover:bg-red-50 hover:text-red-600"
+              variant={'ghost'}
+              onClick={onDeleteUser}
+            >
+              방 나가기
+            </Button>
+          </div>
           <div className="w-full text-xs text-gray-500">
             순위 지정이 불필요하다면 건너뛰셔도 되며, 선택되지 않은 시간은 모두
             4순위로 자동 지정됩니다


### PR DESCRIPTION
- ViewResult를 EntryLayout 외부로 분리 및 Outlet context 제거
- 결과 페이지는 로그인 없이 누구나 조회 가능
- EntryTimetable, EntryRank에 방 나가기 기능 구현
- EntryComplete에서 entryStore reset