### PR TITLE
Fix/11

### DIFF
--- a/FiTime-FE/src/components/result/TimeSlotCardContainer.tsx
+++ b/FiTime-FE/src/components/result/TimeSlotCardContainer.tsx
@@ -31,8 +31,8 @@ export function TimeSlotCardContainer({ results = [] }: TimeSlotCardProps) {
             </div>
             {/* 불가능한 유저 */}
             <div className={'text-gray-500 text-sm/[20px]'}>
-              {it.unavailableUsers.length > 0
-                ? joinUserNames(it.unavailableUsers)
+              {it.unavailable_users.length > 0
+                ? joinUserNames(it.unavailable_users)
                 : '모두 참석 가능!'}
             </div>
           </div>

--- a/FiTime-FE/src/components/timetable/TimeTable.tsx
+++ b/FiTime-FE/src/components/timetable/TimeTable.tsx
@@ -85,10 +85,10 @@ const TimeTable = ({
 
       // Color based on priority (1 = highest priority)
       const heatmapColors = [
-        'bg-violet-700', // priority 1
-        'bg-violet-500', // priority 2
-        'bg-violet-300', // priority 3
-        'bg-violet-100', // priority 4+
+        'bg-violet-100', // priority 1
+        'bg-violet-300', // priority 2
+        'bg-violet-500', // priority 3
+        'bg-violet-700', // priority 4+
       ];
 
       // Find color index of matching priority

--- a/FiTime-FE/src/lib/solutionUtils.ts
+++ b/FiTime-FE/src/lib/solutionUtils.ts
@@ -1,0 +1,122 @@
+import type { SolutionResponse, SolutionUserEntry } from '@/types/api';
+
+/**
+ * Merges consecutive time slots and includes subsets of unavailable users.
+ * Filters out slots where everyone is unavailable.
+ *
+ * @param solutions - Array of solution entries from the API
+ * @param totalUsers - Total number of users in the room
+ * @returns Merged and sorted solution entries
+ */
+export const mergeSolutionTimeSlots = (
+  solutions: SolutionResponse['solution'],
+  totalUsers: number,
+): SolutionResponse['solution'] => {
+  if (!solutions || solutions.length === 0) return [];
+
+  // Filter out slots where everyone is unavailable
+  const validSolutions = solutions.filter(
+    (slot) => slot.unavailable_users.length < totalUsers,
+  );
+
+  if (validSolutions.length === 0) return [];
+
+  // Helper to create a unique key for a set of unavailable users - I hate JS...
+  const getUserKey = (users: SolutionUserEntry[]) => {
+    return users
+      .map((u) => u.username)
+      .sort()
+      .join(',');
+  };
+
+  // Helper to check if setA is a subset of setB - Needed for merging unavailable timeslots
+  const isSubset = (setA: SolutionUserEntry[], setB: SolutionUserEntry[]) => {
+    const keysB = new Set(setB.map((u) => u.username));
+    return setA.every((u) => keysB.has(u.username));
+  };
+
+  // Group by day first - Who the hell has meeting at 2AM? idk.
+  const dayGroups = new Map<number, SolutionResponse['solution']>();
+  validSolutions.forEach((slot) => {
+    if (!dayGroups.has(slot.day)) {
+      dayGroups.set(slot.day, []);
+    }
+    dayGroups.get(slot.day)!.push(slot);
+  });
+
+  const merged: SolutionResponse['solution'] = [];
+
+  dayGroups.forEach((daySlots) => {
+    // Find all unique sets of unavailable users for this day
+    const uniqueUnavailableSets = new Map<string, SolutionUserEntry[]>();
+    daySlots.forEach((slot) => {
+      const key = getUserKey(slot.unavailable_users);
+      if (!uniqueUnavailableSets.has(key)) {
+        uniqueUnavailableSets.set(key, slot.unavailable_users);
+      }
+    });
+
+    // For each unique set of unavailable users
+    uniqueUnavailableSets.forEach((unavailableSet, setKey) => {
+      // Find all slots where unavailable_users is a subset of this set
+      // (including slots with fewer unavailable users, as they're better options)
+      // 03:00~08:00 Alice, 04:00~10:00 Bob -> 04:00~08:00 (1st) + 03:00~08:00 (Without Bob), 04:00~10:00 (Without Alice)
+      // NOT 04:00~08:00 (1st) + 03:00~04:00 (Without Bob), 08:00~10:00 (Without Alice)
+      // The logic is kinda heavy...
+      const compatibleSlots = daySlots.filter((slot) =>
+        isSubset(slot.unavailable_users, unavailableSet),
+      );
+
+      // Find the best rank among slots with exact match of unavailable users
+      const exactMatchSlots = daySlots.filter(
+        (slot) => getUserKey(slot.unavailable_users) === setKey,
+      );
+      const bestRank =
+        exactMatchSlots.length > 0
+          ? Math.min(...exactMatchSlots.map((s) => s.rank))
+          : compatibleSlots.length > 0
+            ? Math.min(...compatibleSlots.map((s) => s.rank))
+            : 999;
+
+      // Sort by start_hour
+      compatibleSlots.sort((a, b) => a.start_hour - b.start_hour);
+
+      // Merge consecutive slots
+      if (compatibleSlots.length > 0) {
+        let current = {
+          ...compatibleSlots[0],
+          unavailable_users: unavailableSet,
+          rank: bestRank,
+        };
+
+        // Since the list is sorted, we can use the greedy approach
+        for (let i = 1; i < compatibleSlots.length; i++) {
+          const slot = compatibleSlots[i];
+          // Check if consecutive
+          // TODO: We should check this behavior; Backend returns start_hour = end_hour; Assuming the interval is 1 hour
+          if (current.end_hour + 1 === slot.start_hour) {
+            // Merge by extending end_hour
+            current.end_hour = slot.end_hour;
+          } else {
+            // Not consecutive, push current and start new
+            merged.push(current);
+            current = {
+              ...slot,
+              unavailable_users: unavailableSet,
+              rank: bestRank,
+            };
+          }
+        }
+        // Don't forget the last one
+        merged.push(current);
+      }
+    });
+  });
+
+  // Sort final result by rank, then day, then start_hour
+  return merged.sort((a, b) => {
+    if (a.rank !== b.rank) return a.rank - b.rank;
+    if (a.day !== b.day) return a.day - b.day;
+    return a.start_hour - b.start_hour;
+  });
+};

--- a/FiTime-FE/src/mocks/solutionData.json
+++ b/FiTime-FE/src/mocks/solutionData.json
@@ -1,20 +1,20 @@
 {
   "status": "success",
   "message": "Solution retrieved successfully",
-  "solutions": [
+  "solution": [
     {
       "day": 1,
       "start_hour": 14,
       "end_hour": 16,
       "rank": 1,
-      "unavailableUsers": []
+      "unavailable_users": []
     },
     {
       "day": 2,
       "start_hour": 10,
       "end_hour": 12,
       "rank": 2,
-      "unavailableUsers": [
+      "unavailable_users": [
         {
           "username": "지우"
         }
@@ -25,7 +25,7 @@
       "start_hour": 18,
       "end_hour": 20,
       "rank": 3,
-      "unavailableUsers": [
+      "unavailable_users": [
         {
           "username": "영민"
         },

--- a/FiTime-FE/src/types/api.ts
+++ b/FiTime-FE/src/types/api.ts
@@ -1,7 +1,7 @@
 export interface SolutionResponse {
   status: string;
   message: string;
-  solutions: SolutionEntry[];
+  solution: SolutionEntry[];
 }
 
 export interface SolutionEntry {
@@ -9,7 +9,7 @@ export interface SolutionEntry {
   start_hour: number;
   end_hour: number;
   rank: number;
-  unavailableUsers: SolutionUserEntry[];
+  unavailable_users: SolutionUserEntry[];
 }
 
 export interface SolutionUserEntry {


### PR DESCRIPTION
### 수정 사항
- Resolves #11 
- TimeSlotCardContainer 관련 로직 수정
  - 설계 당시 Backend에서 TimeSlot이 아닌 TimeSpan (10:00~23:00)을 줄 것으로 기대하고 만들어진 Component임
  - 그러나 실제로는 각각의 TimeSlot (10:00~10:00, 11:00~11:00, ..., 23:00~23:00)이 합쳐지지 않은 채로 보내주는 것으로 확인됨
  - Front 단에서 이를 합치는 로직을 수행 (`mergeSolutionTimeSlots()`)
    - 기본적으로 같은 `unavailable_users` Set을 가지는 TimeSlot끼리 묶어 TimeSpan을 만듦
    - 그러나 `unavailable_users` Subset의 TimeSlot 또한 같이 묶어줘야 함 (Rank는 반영하지 않음)
    - 이에 대한 상세한 로직은 주석으로 설명되어 있으니 참고